### PR TITLE
Please include the test source files in the cabal sdist tarball

### DIFF
--- a/fsnotify.cabal
+++ b/fsnotify.cabal
@@ -13,6 +13,10 @@ Description:            Cross platform library for file creation, modification,
 Category:               Filesystem
 Cabal-Version:          >= 1.8
 Build-Type:             Simple
+Extra-Source-Files:     test/FSNotify.hs
+                        test/Path.hs
+                        test/Util.hs
+                        test/watch-here.hs
 
 
 Library


### PR DESCRIPTION
As we build the tests on Gentoo.  After copying the missing tests they pass with ghc 7.6.1 on Gentoo with hinotify 0.3.5 after I changed this dep to >= instead of == (I was tempted to request loosening that dep in this pull request, but I haven't, the missing tests give us more trouble than silly == deps).
