### PR TITLE
Export EventChannel, Action and ActionPredicate type aliases

### DIFF
--- a/src/System/FSNotify.hs
+++ b/src/System/FSNotify.hs
@@ -8,7 +8,10 @@
 
 module System.FSNotify
        ( Event(..)
- 
+       , EventChannel
+       , Action
+       , ActionPredicate
+
        -- * Starting/Stopping
        , WatchManager
        , withManager


### PR DESCRIPTION
These types are used in the public API as callbacks the user should supply, but they are not exported. This patch fixes it.
