### PR TITLE
Improve documentation

### DIFF
--- a/src/System/FSNotify.hs
+++ b/src/System/FSNotify.hs
@@ -4,7 +4,10 @@
 --
 {-# LANGUAGE CPP, ScopedTypeVariables, ExistentialQuantification, RankNTypes #-}
 
--- | Minimal example:
+-- | NOTE: This library does not currently report changes made to directories,
+-- only files within watched directories.
+--
+-- Minimal example:
 --
 -- >{-# LANGUAGE OverloadedStrings #-} -- for FilePath literals
 -- >
@@ -92,6 +95,12 @@ data WatchManager
        (MVar (Maybe (IO ()))) -- cleanup action, or Nothing if the manager is stopped
 
 -- | Default configuration
+--
+-- * Debouncing is enabled with a time interval of 1 millisecond
+--
+-- * Polling is disabled
+--
+-- * The polling interval defaults to 1 second
 defaultConfig :: WatchConfig
 defaultConfig =
   WatchConfig

--- a/src/System/FSNotify/Types.hs
+++ b/src/System/FSNotify/Types.hs
@@ -61,11 +61,21 @@ data WatchConfig = WatchConfig
     -- available. This is mostly for testing purposes.
   }
 
--- | This specifies whether events close to each other should be collapsed
--- together, and how close is close enough.
+-- | This specifies whether multiple events from the same file should be
+-- collapsed together, and how close is close enough.
+--
+-- This is performed by ignoring any event that occurs to the same file
+-- until the specified time interval has elapsed.
+--
+-- Note that the current debouncing logic may fail to report certain changes
+-- to a file, potentially leaving your program in a state that is not
+-- consistent with the filesystem.
+--
+-- Make sure that if you are using this feature, all changes you make as a
+-- result of an 'Event' notification are both non-essential and idempotent.
 data Debounce
   = DebounceDefault
-    -- ^ perform debouncing based on the default time interval
+    -- ^ perform debouncing based on the default time interval of 1 millisecond
   | Debounce NominalDiffTime
     -- ^ perform debouncing based on the specified time interval
   | NoDebounce


### PR DESCRIPTION
The following information currently requires looking through the source code to discover:

* Polling is not used by default.
* The default poll interval is 1 second.
* Debouncing is enabled by default.
* The default time interval for debouncing is 1 millisecond.
* Debouncing logic simply drops successive changes to a file if made within the specified debounce time interval.

While reported, it was not obvious to me that changes to directories are not reported on. I think some of the wording should be changed to make this a little more apparent.