### PR TITLE
Fix build warnings when compiling test suite

### DIFF
--- a/test/EventUtils.hs
+++ b/test/EventUtils.hs
@@ -4,7 +4,7 @@ module EventUtils where
 import Prelude hiding (FilePath)
 import Test.Tasty.HUnit
 import Control.Concurrent
-import Control.Concurrent.Async
+import Control.Concurrent.Async hiding (poll)
 import Control.Applicative
 import Control.Monad
 import Data.IORef
@@ -73,7 +73,7 @@ gatherEvents poll watch path = do
   mgr <- startManagerConf defaultConfig
     { confDebounce = NoDebounce
     , confUsePolling = poll
-    , confPollInterval = 2 * 10^5
+    , confPollInterval = 2 * 10^(5 :: Int)
     }
   eventsVar <- newIORef []
   stop <- watch mgr path (const True) (\ev -> atomicModifyIORef eventsVar (\evs -> (ev:evs, ())))
@@ -96,5 +96,8 @@ expectEvents poll w path pats action = do
 testDirPath :: FilePath
 testDirPath = decodeString (unsafePerformIO getCurrentDirectory) </> "testdir"
 
+expectEventsHere :: (?timeInterval::Int) => Bool -> [EventPattern] -> IO () -> Assertion
 expectEventsHere poll = expectEvents poll watchDir testDirPath
+
+expectEventsHereRec :: (?timeInterval::Int) => Bool -> [EventPattern] -> IO () -> Assertion
 expectEventsHereRec poll = expectEvents poll watchTree testDirPath


### PR DESCRIPTION
The following build warnings are currently emitted when compiling the hfsnotify test suite:

```
test/EventUtils.hs:72:14: Warning:
    This binding for `poll' shadows the existing binding
      imported from `Control.Concurrent.Async' at test/EventUtils.hs:7:1-31

test/EventUtils.hs:76:32: Warning:
    Defaulting the following constraint(s) to type `Integer'
      (Integral b0) arising from a use of `^' at test/EventUtils.hs:76:32
      (Num b0) arising from the literal `5' at test/EventUtils.hs:76:33
    In the second argument of `(*)', namely `10 ^ 5'
    In the `confPollInterval' field of a record
    In the first argument of `startManagerConf', namely
      `defaultConfig
         {confDebounce = NoDebounce, confUsePolling = poll,
          confPollInterval = 2 * 10 ^ 5}'

test/EventUtils.hs:90:14: Warning:
    This binding for `poll' shadows the existing binding
      imported from `Control.Concurrent.Async' at test/EventUtils.hs:7:1-31

test/EventUtils.hs:99:1: Warning:
    Top-level binding with no type signature:
      expectEventsHere :: (?timeInterval::Int) =>
                          Bool -> [EventPattern] -> IO () -> Assertion

test/EventUtils.hs:99:18: Warning:
    This binding for `poll' shadows the existing binding
      imported from `Control.Concurrent.Async' at test/EventUtils.hs:7:1-31

test/EventUtils.hs:100:1: Warning:
    Top-level binding with no type signature:
      expectEventsHereRec :: (?timeInterval::Int) =>
                             Bool -> [EventPattern] -> IO () -> Assertion

test/EventUtils.hs:100:21: Warning:
    This binding for `poll' shadows the existing binding
      imported from `Control.Concurrent.Async' at test/EventUtils.hs:7:1-31

test/test.hs:11:1: Warning:
    The import of `Text.Printf' is redundant
      except perhaps to import instances from `Text.Printf'
    To import instances alone, use: import Text.Printf()

test/test.hs:24:1: Warning:
    Top-level binding with no type signature: main :: IO ()

test/test.hs:34:1: Warning:
    Top-level binding with no type signature: tests :: Bool -> TestTree

test/test.hs:41:20: Warning:
    Defaulting the following constraint(s) to type `Integer'
      (Integral b0) arising from a use of `^' at test/test.hs:41:20
      (Num b0) arising from the literal `6' at test/test.hs:41:21
    In the second argument of `(*)', namely `10 ^ 6'
    In the expression: 2 * 10 ^ 6
    In the expression: if poll then 2 * 10 ^ 6 else 5 * 10 ^ 5

test/test.hs:42:20: Warning:
    Defaulting the following constraint(s) to type `Integer'
      (Integral b0) arising from a use of `^' at test/test.hs:42:20
      (Num b0) arising from the literal `5' at test/test.hs:42:21
    In the second argument of `(*)', namely `10 ^ 5'
    In the expression: 5 * 10 ^ 5
    In the expression: if poll then 2 * 10 ^ 6 else 5 * 10 ^ 5

test/test.hs:54:43: Warning:
    Defaulting the following constraint(s) to type `Integer'
      (Integral b0) arising from a use of `^' at test/test.hs:54:43
      (Num b0) arising from the literal `6' at test/test.hs:54:44
    In the second argument of `($)', namely `10 ^ 6'
    In the second argument of `when', namely `(threadDelay $ 10 ^ 6)'
    In the first argument of `(>>)', namely
      `when poll (threadDelay $ 10 ^ 6)'

test/test.hs:75:5: Warning:
    This binding for `filename' shadows the existing binding
      imported from `Filesystem.Path.CurrentOS' at test/test.hs:8:1-32
      (and originally defined in `Filesystem.Path')
```