### PR TITLE
Remove references to deprecated system-filepath for Windows and OSX

### DIFF
--- a/fsnotify.cabal
+++ b/fsnotify.cabal
@@ -45,12 +45,12 @@ Library
     if os(windows)
       CPP-Options:      -DOS_Win32
       Other-Modules:    System.FSNotify.Win32
-      Build-Depends:    Win32-notify >= 0.3, system-filepath, system-fileio
+      Build-Depends:    Win32-notify >= 0.3
     else
       if os(darwin)
         CPP-Options:    -DOS_Mac
         Other-Modules:  System.FSNotify.OSX
-        Build-Depends:  hfsevents >= 0.1.3, system-filepath, system-fileio
+        Build-Depends:  hfsevents >= 0.1.3
 
 Test-Suite test
   Type:                 exitcode-stdio-1.0

--- a/src/System/FSNotify/OSX.hs
+++ b/src/System/FSNotify/OSX.hs
@@ -2,7 +2,6 @@
 -- Copyright (c) 2012 Mark Dittmer - http://www.markdittmer.org
 -- Developed for a Google Summer of Code project - http://gsoc2012.markdittmer.org
 --
-{-# LANGUAGE MultiParamTypeClasses, TypeSynonymInstances, FlexibleInstances #-}
 
 module System.FSNotify.OSX
        ( FileListener(..)
@@ -20,15 +19,13 @@ import Data.Map (Map)
 import Data.Time.Clock (UTCTime, getCurrentTime)
 import Data.Word
 import Data.Unique
-import Filesystem (isFile)
-import Filesystem.Path hiding (concat)
+import System.FilePath
+import System.Directory
 import System.FSNotify.Listener
 import System.FSNotify.Path (canonicalizeDirPath)
 import System.FSNotify.Types
 import qualified Data.Map as Map
 import qualified System.OSX.FSEvents as FSE
-import Filesystem.Path.CurrentOS hiding (concat)
-import qualified System.IO as SIO
 
 data ListenType = NonRecursive | Recursive
 data WatchData = WatchData FSE.EventStream ListenType EventChannel
@@ -37,15 +34,6 @@ type WatchMap = Map Unique WatchData
 data OSXManager = OSXManager (MVar WatchMap)
 type NativeManager = OSXManager
 
-
-class ConvertFilePath a b where
-  fp :: a -> b
-instance ConvertFilePath FilePath String where fp   = encodeString
-instance ConvertFilePath String FilePath where fp   = decodeString
-instance ConvertFilePath String String where fp     = id
-instance ConvertFilePath FilePath FilePath where fp = id
-
-
 nil :: Word64
 nil = 0x00
 
@@ -53,23 +41,23 @@ nil = 0x00
 -- the trailing slash when the path refers to a directory
 canonicalEventPath :: FSE.Event -> FilePath
 canonicalEventPath event =
-  if flags .&. dirFlag /= nil then path </> empty else path
+  if flags .&. dirFlag /= nil then addTrailingPathSeparator path else path
   where
     flags = FSE.eventFlags event
     dirFlag = FSE.eventFlagItemIsDir
-    path = fp $ FSE.eventPath event
+    path = FSE.eventPath event
 
 fsnEvents :: UTCTime -> FSE.Event -> IO [Event]
 fsnEvents timestamp fseEvent = liftM concat . sequence $ map (\f -> f fseEvent) (eventFunctions timestamp)
   where
     eventFunctions :: UTCTime -> [FSE.Event -> IO [Event]]
     eventFunctions t = [addedFn t, modifFn t, removFn t, renamFn t]
-    addedFn t e = if hasFlag e FSE.eventFlagItemCreated        then return [Added    (encodeString $ path e) t] else return []
+    addedFn t e = if hasFlag e FSE.eventFlagItemCreated        then return [Added    (path e) t] else return []
     modifFn t e = if (hasFlag e FSE.eventFlagItemModified
-                   || hasFlag e FSE.eventFlagItemInodeMetaMod) then return [Modified (encodeString $ path e) t] else return []
-    removFn t e = if hasFlag e FSE.eventFlagItemRemoved        then return [Removed  (encodeString $ path e) t] else return []
+                   || hasFlag e FSE.eventFlagItemInodeMetaMod) then return [Modified (path e) t] else return []
+    removFn t e = if hasFlag e FSE.eventFlagItemRemoved        then return [Removed  (path e) t] else return []
     renamFn t e = if hasFlag e FSE.eventFlagItemRenamed then
-                    isFile (path e) >>= \exists -> if exists   then return [Added    (encodeString $ path e) t] else return [Removed (encodeString $ path e) t]
+                    doesFileExist (path e) >>= \exists -> if exists   then return [Added    (path e) t] else return [Removed (path e) t]
                   else
                     return []
     path = canonicalEventPath
@@ -78,14 +66,14 @@ fsnEvents timestamp fseEvent = liftM concat . sequence $ map (\f -> f fseEvent) 
 -- Separate logic is needed for non-recursive events in OSX because the
 -- hfsevents package doesn't support non-recursive event reporting.
 
-handleNonRecursiveFSEEvent :: ActionPredicate -> EventChannel -> SIO.FilePath -> DebouncePayload -> FSE.Event -> IO ()
+handleNonRecursiveFSEEvent :: ActionPredicate -> EventChannel -> FilePath -> DebouncePayload -> FSE.Event -> IO ()
 handleNonRecursiveFSEEvent actPred chan dirPath dbp fseEvent = do
   currentTime <- getCurrentTime
   events <- fsnEvents currentTime fseEvent
   handleNonRecursiveEvents actPred chan dirPath dbp events
-handleNonRecursiveEvents :: ActionPredicate -> EventChannel -> SIO.FilePath -> DebouncePayload -> [Event] -> IO ()
+handleNonRecursiveEvents :: ActionPredicate -> EventChannel -> FilePath -> DebouncePayload -> [Event] -> IO ()
 handleNonRecursiveEvents actPred chan dirPath dbp (event:events)
-  | directory (decodeString dirPath) == directory (decodeString $ eventPath event) && actPred event = do
+  | takeDirectory dirPath == takeDirectory (eventPath event) && actPred event = do
     case dbp of
       (Just (DebounceData epsilon ior)) -> do
         lastEvent <- readIORef ior
@@ -114,10 +102,10 @@ handleEvents actPred chan dbp (event:events) = do
 handleEvents _ _ _ [] = return ()
 
 listenFn
-  :: (ActionPredicate -> EventChannel -> SIO.FilePath -> DebouncePayload -> FSE.Event -> IO a)
+  :: (ActionPredicate -> EventChannel -> FilePath -> DebouncePayload -> FSE.Event -> IO a)
   -> WatchConfig
   -> OSXManager
-  -> SIO.FilePath
+  -> FilePath
   -> ActionPredicate
   -> EventChannel
   -> IO StopListening
@@ -125,7 +113,7 @@ listenFn handler conf (OSXManager mvarMap) path actPred chan = do
   path' <- canonicalizeDirPath path
   dbp <- newDebouncePayload $ confDebounce conf
   unique <- newUnique
-  eventStream <- FSE.eventStreamCreate [fp path'] 0.0 True False True (handler actPred chan path' dbp)
+  eventStream <- FSE.eventStreamCreate [path'] 0.0 True False True (handler actPred chan path' dbp)
   modifyMVar_ mvarMap $ \watchMap -> return (Map.insert unique (WatchData eventStream NonRecursive chan) watchMap)
   return $ do
     FSE.eventStreamDestroy eventStream
@@ -146,6 +134,6 @@ instance FileListener OSXManager where
 
   listen = listenFn handleNonRecursiveFSEEvent
 
-  listenRecursive = listenFn $ \actPred chan path -> handleFSEEvent actPred chan
+  listenRecursive = listenFn $ \actPred chan _ -> handleFSEEvent actPred chan
 
   usesPolling = const False


### PR DESCRIPTION
Builds on OS-X and Windows, cabal file also updated.
Still working on the tests