### PR TITLE
Catch IO exceptions when initialising inotify on Linux

### DIFF
--- a/src/System/FSNotify/Linux.hs
+++ b/src/System/FSNotify/Linux.hs
@@ -3,6 +3,7 @@
 -- Developed for a Google Summer of Code project - http://gsoc2012.markdittmer.org
 --
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module System.FSNotify.Linux
@@ -66,7 +67,7 @@ varieties :: [INo.EventVariety]
 varieties = [INo.Create, INo.Delete, INo.MoveIn, INo.MoveOut, INo.CloseWrite]
 
 instance FileListener INo.INotify where
-  initSession = fmap Just INo.initINotify
+  initSession = catch (fmap Just INo.initINotify) (\(_ :: IOException) -> return Nothing)
 
   killSession = INo.killINotify
 

--- a/src/System/FSNotify/Linux.hs
+++ b/src/System/FSNotify/Linux.hs
@@ -4,7 +4,6 @@
 --
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module System.FSNotify.Linux
@@ -12,15 +11,12 @@ module System.FSNotify.Linux
        , NativeManager
        ) where
 
-#if __GLASGOW_HASKELL__ >= 706
 import Prelude hiding (FilePath)
-#else
-import Prelude hiding (FilePath, catch)
-#endif
+
 
 import Control.Concurrent.Chan
 import Control.Concurrent.MVar
-import Control.Exception
+import Control.Exception as E
 import Control.Monad (when)
 import Data.IORef (atomicModifyIORef, readIORef)
 import Data.Time.Clock (UTCTime, getCurrentTime)
@@ -72,7 +68,7 @@ varieties :: [INo.EventVariety]
 varieties = [INo.Create, INo.Delete, INo.MoveIn, INo.MoveOut, INo.CloseWrite]
 
 instance FileListener INo.INotify where
-  initSession = catch (fmap Just INo.initINotify) (\(_ :: IOException) -> return Nothing)
+  initSession = E.catch (fmap Just INo.initINotify) (\(_ :: IOException) -> return Nothing)
 
   killSession = INo.killINotify
 

--- a/src/System/FSNotify/Linux.hs
+++ b/src/System/FSNotify/Linux.hs
@@ -4,6 +4,7 @@
 --
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module System.FSNotify.Linux
@@ -11,7 +12,11 @@ module System.FSNotify.Linux
        , NativeManager
        ) where
 
+#if __GLASGOW_HASKELL__ >= 706
 import Prelude hiding (FilePath)
+#else
+import Prelude hiding (FilePath, catch)
+#endif
 
 import Control.Concurrent.Chan
 import Control.Concurrent.MVar


### PR DESCRIPTION
@feuerbach
See snoyberg/keter#167 for more info on the background behind this PR. I have tested this PR manually on the environment mentioned in that issue, where `initInotify` isn't available, and as expected hfsnotify switched to polling. I have only added exception catching for Linux as I am not running or testing on any other platforms, and wanted this PR to be as small as possible.