### PR TITLE
Add upper bound on hinotify since 0.3.10 introduced a breaking change

### DIFF
--- a/fsnotify.cabal
+++ b/fsnotify.cabal
@@ -40,7 +40,7 @@ Library
   if os(linux)
     CPP-Options:        -DOS_Linux
     Other-Modules:      System.FSNotify.Linux
-    Build-Depends:      hinotify >= 0.3.7
+    Build-Depends:      hinotify >= 0.3.7 && < 0.3.10
   else
     if os(windows)
       CPP-Options:      -DOS_Win32


### PR DESCRIPTION
As a hackage trustee, I've made revisions to prevent this breakage on existing versions of `fsnotify`