### PR TITLE
Add compatibility with hinotify-0.3.10

### DIFF
--- a/fsnotify.cabal
+++ b/fsnotify.cabal
@@ -22,6 +22,7 @@ Extra-Source-Files:
 
 Library
   Build-Depends:          base >= 4.3.1 && < 5
+                        , bytestring >= 0.10.2
                         , containers >= 0.4
                         , directory >= 1.1.0.0
                         , filepath >= 1.3.0.0

--- a/fsnotify.cabal
+++ b/fsnotify.cabal
@@ -41,7 +41,7 @@ Library
   if os(linux)
     CPP-Options:        -DOS_Linux
     Other-Modules:      System.FSNotify.Linux
-    Build-Depends:      hinotify >= 0.3.7
+    Build-Depends:      hinotify >= 0.3.10
   else
     if os(windows)
       CPP-Options:      -DOS_Win32


### PR DESCRIPTION
close #75 

From the ticket discussion: 

> hinotify switched to RawFilePath in 11c4d31a95ad36f954fac6728e47042a92e4466a

I looked into the commit https://github.com/kolmodin/hinotify/commit/11c4d31a95ad36f954fac6728e47042a92e4466a and implemented the conversions from/to `ByteString` that previously were done by `hinotify`. So the logic should've stayed the same