### PR TITLE
Update base bound to lowest tested version

### DIFF
--- a/fsnotify.cabal
+++ b/fsnotify.cabal
@@ -21,7 +21,7 @@ Extra-Source-Files:
 
 
 Library
-  Build-Depends:          base >= 4.3.1 && < 5
+  Build-Depends:          base >= 4.8 && < 5
                         , bytestring >= 0.10.2
                         , containers >= 0.4
                         , directory >= 1.1.0.0


### PR DESCRIPTION
Currently this package does not build below GHC 7.10, so I've updated the base bound

As a hackage trustee, I have made hackage metadata revisions to versions 0.3.0.0 and 0.3.0.1 with this change.