### PR TITLE
Ability to control if separate threads should be created to handle events

### DIFF
--- a/src/System/FSNotify.hs
+++ b/src/System/FSNotify.hs
@@ -209,7 +209,7 @@ threadChan listenFn (WatchManager db listener cleanupVar) path actPred action =
         )
 
 readEvents :: WatchConfig -> EventChannel -> Action -> IO ()
-readEvents (WatchConfig _ _ _ True) chan action = forever $ do
+readEvents WatchConfig {confThreadPerEvent=True} chan action = forever $ do
   event <- readChan chan
   us <- myThreadId
   -- Execute the event handler in a separate thread, but throw any
@@ -220,7 +220,7 @@ readEvents (WatchConfig _ _ _ True) chan action = forever $ do
   -- thread is dead). How bad is that? The alternative is to kill the
   -- handler anyway when we're cancelling.
   forkFinally (action event) $ either (throwTo us) (const $ return ())
-readEvents (WatchConfig _ _ _ False) chan action =
+readEvents WatchConfig {confThreadPerEvent=False} chan action =
   forever $ action =<< readChan chan
 
 #if !MIN_VERSION_base(4,6,0)

--- a/src/System/FSNotify/Types.hs
+++ b/src/System/FSNotify/Types.hs
@@ -69,6 +69,9 @@ data WatchConfig = WatchConfig
   , confUsePolling :: Bool
     -- ^ Force use of polling, even if a more effective method may be
     -- available. This is mostly for testing purposes.
+  , confThreadPerEvent :: Bool
+    -- ^ If separate thread should be created for each event
+    -- (file change) to execute user supplied event handler
   }
 
 -- | This specifies whether multiple events from the same file should be

--- a/src/System/FSNotify/Types.hs
+++ b/src/System/FSNotify/Types.hs
@@ -70,8 +70,8 @@ data WatchConfig = WatchConfig
     -- ^ Force use of polling, even if a more effective method may be
     -- available. This is mostly for testing purposes.
   , confThreadPerEvent :: Bool
-    -- ^ If separate thread should be created for each event
-    -- (file change) to execute user supplied event handler
+    -- ^ Fork a separate thread for each event when executing the
+    -- user supplied event handler
   }
 
 -- | This specifies whether multiple events from the same file should be


### PR DESCRIPTION
I was using this library for a while now and in my case I needed to synchronise all of the threads (MVar)created by hfnotify library. But why create threads at all if I know I'll execute them synchronously. This PR allows to control that via new `WatchConfig` parameter  