### PR TITLE
Correct file does not exists warning in cabal

### DIFF
--- a/fsnotify.cabal
+++ b/fsnotify.cabal
@@ -16,7 +16,7 @@ Homepage:               https://github.com/haskell-fswatch/hfsnotify
 Extra-Source-Files:
   README.md
   CHANGELOG.md
-  test/Test.hs
+  test/Main.hs
 
 
 Library


### PR DESCRIPTION
https://github.com/haskell-fswatch/hfsnotify/runs/1300807157?check_suite_focus=true

```
Warning: File listed in fsnotify.cabal file does not exist: test/Test.hs
```