### PR TITLE
Use polling as a generic fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,3 +128,53 @@ jobs:
     - name: Test
       run: |
         stack test $STACK_EXTRA_ARGS
+
+  wasm:
+    runs-on: ubuntu-latest
+    env:
+      GHC_WASM_META_REV: 45f73c3e075fa38efe84055b0dba87996948101d
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: ['9.10']
+    steps:
+    - name: Install happy
+      run: |
+        cabal path --installdir >> "$GITHUB_PATH"
+        cabal update -z
+        cabal install -z happy
+
+    - name: Setup ghc-wasm32-wasi
+      run: |
+        cd "$(mktemp -d)"
+        curl -L "https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta/-/archive/${GHC_WASM_META_REV}/ghc-wasm-meta.tar.gz" | tar xz --strip-components=1
+        ./setup.sh
+        ~/.ghc-wasm/add_to_github_path.sh
+
+    - uses: actions/checkout@v4
+
+    - uses: actions/cache/restore@v4
+      id: cache-restore
+      with:
+        path: |
+          ~/.ghc-wasm/.cabal/store
+        key: wasi-${{ runner.os }}-${{ env.GHC_WASM_META_REV }}-flavour-${{ matrix.ghc }}-${{ github.sha }}
+        restore-keys: |
+          wasi-${{ runner.os }}-${{ env.GHC_WASM_META_REV }}-flavour-${{ matrix.ghc }}-
+
+    - name: Build
+      run: |
+        wasm32-wasi-cabal build all
+        wasm32-wasi-cabal list-bin exe:example
+
+    - name: Test
+      # The test suite doesn't compile due to the sandwich dependency, so we only run the example app.
+      run: |
+        wasmtime.sh "$(wasm32-wasi-cabal list-bin exe:example)"
+
+    - uses: actions/cache/save@v4
+      if: always() && steps.cache-restore.outputs.cache-hit != 'true'
+      with:
+        path: |
+          ~/.ghc-wasm/.cabal/store
+        key: ${{ steps.cache-restore.outputs.cache-primary-key }}

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,8 @@
+packages: .
+
+if arch(wasm32)
+  -- https://github.com/haskell/network/pull/598
+  source-repository-package
+    type: git
+    location: https://github.com/haskell-wasm/network
+    tag: ab92e48e9fdf3abe214f85fdbe5301c1280e14e9

--- a/fsnotify.cabal
+++ b/fsnotify.cabal
@@ -89,7 +89,7 @@ executable example
       example
   default-extensions:
       ScopedTypeVariables
-  ghc-options: -threaded -Wall
+  ghc-options: -Wall
   build-depends:
       base
     , directory
@@ -111,6 +111,8 @@ executable example
     cpp-options: -DOS_Win32 -DHAVE_NATIVE_WATCHER
   if os(darwin)
     cpp-options: -DOS_Mac -DHAVE_NATIVE_WATCHER
+  if !arch(wasm32)
+    ghc-options: -threaded
 
 test-suite tests
   type: exitcode-stdio-1.0

--- a/fsnotify.cabal
+++ b/fsnotify.cabal
@@ -49,13 +49,11 @@ library
     , unix-compat >=0.2
   default-language: Haskell2010
   if os(linux)
-    cpp-options: -DOS_Linux
+    cpp-options: -DOS_Linux -DHAVE_NATIVE_WATCHER
   if os(windows)
-    cpp-options: -DOS_Win32
+    cpp-options: -DOS_Win32 -DHAVE_NATIVE_WATCHER
   if os(darwin)
-    cpp-options: -DOS_Mac
-  if os(freebsd) || os(netbsd) || os(openbsd)
-    cpp-options: -DOS_BSD
+    cpp-options: -DOS_Mac -DHAVE_NATIVE_WATCHER
   if os(linux)
     other-modules:
         System.FSNotify.Linux
@@ -108,13 +106,11 @@ executable example
     , unliftio
   default-language: Haskell2010
   if os(linux)
-    cpp-options: -DOS_Linux
+    cpp-options: -DOS_Linux -DHAVE_NATIVE_WATCHER
   if os(windows)
-    cpp-options: -DOS_Win32
+    cpp-options: -DOS_Win32 -DHAVE_NATIVE_WATCHER
   if os(darwin)
-    cpp-options: -DOS_Mac
-  if os(freebsd) || os(netbsd) || os(openbsd)
-    cpp-options: -DOS_BSD
+    cpp-options: -DOS_Mac -DHAVE_NATIVE_WATCHER
 
 test-suite tests
   type: exitcode-stdio-1.0
@@ -145,13 +141,11 @@ test-suite tests
     , unliftio >=0.2.20
   default-language: Haskell2010
   if os(linux)
-    cpp-options: -DOS_Linux
+    cpp-options: -DOS_Linux -DHAVE_NATIVE_WATCHER
   if os(windows)
-    cpp-options: -DOS_Win32
+    cpp-options: -DOS_Win32 -DHAVE_NATIVE_WATCHER
   if os(darwin)
-    cpp-options: -DOS_Mac
-  if os(freebsd) || os(netbsd) || os(openbsd)
-    cpp-options: -DOS_BSD
+    cpp-options: -DOS_Mac -DHAVE_NATIVE_WATCHER
   if os(windows)
     build-depends:
         Win32

--- a/package.yaml
+++ b/package.yaml
@@ -16,13 +16,11 @@ extra-source-files:
 
 when:
 - condition: os(linux)
-  cpp-options: -DOS_Linux
+  cpp-options: -DOS_Linux -DHAVE_NATIVE_WATCHER
 - condition: os(windows)
-  cpp-options: -DOS_Win32
+  cpp-options: -DOS_Win32 -DHAVE_NATIVE_WATCHER
 - condition: os(darwin)
-  cpp-options: -DOS_Mac
-- condition: os(freebsd) || os(netbsd) || os(openbsd)
-  cpp-options: -DOS_BSD
+  cpp-options: -DOS_Mac -DHAVE_NATIVE_WATCHER
 
 default-extensions:
 - ScopedTypeVariables

--- a/package.yaml
+++ b/package.yaml
@@ -90,8 +90,11 @@ executables:
     source-dirs:
     - example
     ghc-options:
-    - -threaded
     - -Wall
+    when:
+    - condition: '!arch(wasm32)'
+      ghc-options:
+      - -threaded
     dependencies:
     - base
     - directory

--- a/src/System/FSNotify/Types.hs
+++ b/src/System/FSNotify/Types.hs
@@ -61,10 +61,10 @@ data WatchMode =
   }
   -- ^ Detect changes by polling the filesystem. Less efficient and may miss fast changes. Not recommended
   -- unless you're experiencing problems with 'WatchModeOS' (or 'WatchModeOS' is not supported on your platform).
-#ifndef OS_BSD
+#ifdef HAVE_NATIVE_WATCHER
   | WatchModeOS
   -- ^ Use OS-specific mechanisms to be notified of changes (inotify on Linux, FSEvents on OSX, etc.).
-  -- Not currently available on *BSD.
+  -- Not currently available on e.g. *BSD and Wasm/WASI.
 #endif
 
 data ThreadingMode =

--- a/test/FSNotify/Test/EventTests.hs
+++ b/test/FSNotify/Test/EventTests.hs
@@ -32,7 +32,7 @@ eventTests :: (
   MonadUnliftIO m, MonadThrow m
   ) => TestFolderGenerator -> ThreadingMode -> SpecFree context m ()
 eventTests testFolderGenerator threadingMode = describe "Tests" $ parallelWithoutDirectory $ do
-  let pollOptions = if isBSD then [True] else [False, True]
+  let pollOptions = if haveNativeWatcher then [False, True] else [True]
 
   forM_ pollOptions $ \poll -> describe (if poll then "Polling" else "Native") $ parallelWithoutDirectory $ do
     forM_ [False, True] $ \recursive -> describe (if recursive then "Recursive" else "Non-recursive") $ parallelWithoutDirectory $

--- a/test/FSNotify/Test/Util.hs
+++ b/test/FSNotify/Test/Util.hs
@@ -66,11 +66,11 @@ isLinux = True
 isLinux = False
 #endif
 
-isBSD :: Bool
-#ifdef OS_BSD
-isBSD = True
+haveNativeWatcher :: Bool
+#ifdef HAVE_NATIVE_WATCHER
+haveNativeWatcher = True
 #else
-isBSD = False
+haveNativeWatcher = False
 #endif
 
 waitUntil :: MonadUnliftIO m => Double -> m a -> m a
@@ -159,7 +159,7 @@ withTestFolder testFolderGenerator threadingMode poll recursive nested setup act
     threadDelay (max 5_000_000 (3 * pollInterval))
 
     let conf = defaultConfig {
-#ifdef OS_BSD
+#ifndef HAVE_NATIVE_WATCHER
           confWatchMode = if poll then WatchModePoll pollInterval else error "No native watcher available."
 #else
           confWatchMode = if poll then WatchModePoll pollInterval else WatchModeOS


### PR DESCRIPTION
Right now, using polling as a fallback if no native watcher is available is only done for BSDs, but I think there is no reason to not simply extend this fallback to all platforms other than Linux, macOS and Windows.

As a motivating example, the [WASI target](https://wasi.dev/) (see the [GHC Wasm backend](https://www.tweag.io/blog/2022-11-22-wasm-backend-merged-in-ghc/)) does **not** provide a native file watching interface. With this patch, fsnotify compiles just fine on that backend, by using the generic polling fallback.