### PR TITLE
Fix conflation in the Added constructor

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -7,6 +7,8 @@ import Control.Concurrent
 import Data.String.Interpolate
 import System.FSNotify
 import System.FilePath
+import System.IO
+import qualified System.PosixCompat as System.Directory
 import UnliftIO.Temporary
 
 
@@ -24,6 +26,19 @@ main = do
 
       putStrLn [i|Writing to #{dir </> "bar"}|]
       writeFile (dir </> "bar") "asdf"
+      threadDelay 3_000_000
+
+      putStrLn [i|Direct write|]
+      withFile (dir </> "direct-quux") WriteMode $ \hQuux -> do
+        hPutStrLn hQuux "aaaaa" >> threadDelay 300_000
+        hPutStrLn hQuux "bbbbb" >> threadDelay 300_000
+        hPutStrLn hQuux "ccccc" >> threadDelay 300_000
+        hClose hQuux
+
+      putStrLn [i|Atomic mv|]
+      withSystemTempFile "atomic-quux" $ \quuxFp quuxH -> do
+        hClose quuxH
+        System.Directory.rename quuxFp (dir </> "quux.moved-in")
       threadDelay 3_000_000
 
       putStrLn [i|Stopping|]

--- a/src/System/FSNotify/Linux.hs
+++ b/src/System/FSNotify/Linux.hs
@@ -53,13 +53,13 @@ fsnEvents basePath' timestamp (INo.Closed (boolToIsDirectory -> isDir) (Just raw
   fromHinotifyPath raw >>= \name -> return [CloseWrite (basePath </> name) timestamp isDir]
 fsnEvents basePath' timestamp (INo.Created (boolToIsDirectory -> isDir) raw) = do
   basePath <- fromRawFilePath basePath'
-  fromHinotifyPath raw >>= \name -> return [Added (basePath </> name) timestamp isDir]
+  fromHinotifyPath raw >>= \name -> return [Added (basePath </> name) timestamp isDir False]
 fsnEvents basePath' timestamp (INo.MovedOut (boolToIsDirectory -> isDir) raw _cookie) = do
   basePath <- fromRawFilePath basePath'
   fromHinotifyPath raw >>= \name -> return [Removed (basePath </> name) timestamp isDir]
 fsnEvents basePath' timestamp (INo.MovedIn (boolToIsDirectory -> isDir) raw _cookie) = do
   basePath <- fromRawFilePath basePath'
-  fromHinotifyPath raw >>= \name -> return [Added (basePath </> name) timestamp isDir]
+  fromHinotifyPath raw >>= \name -> return [Added (basePath </> name) timestamp isDir True]
 fsnEvents basePath' timestamp (INo.Deleted (boolToIsDirectory -> isDir) raw) = do
   basePath <- fromRawFilePath basePath'
   fromHinotifyPath raw >>= \name -> return [Removed (basePath </> name) timestamp isDir]

--- a/src/System/FSNotify/Linux.hs
+++ b/src/System/FSNotify/Linux.hs
@@ -163,7 +163,10 @@ handleRecursiveEvent baseDir actPred callback watchStillExistsVar isRootWatchedD
         let modTime = modificationTimeHiRes fileStatus
         when (modTime > timestampBeforeAddingWatch) $ do
           let isDir = if isDirectory fileStatus then IsDirectory else IsFile
-          let addedEvent = (Added (newDir </> newPath) (posixSecondsToUTCTime timestampBeforeAddingWatch) isDir)
+          -- Assuming non-atomic here is safe default, because we're resynthesizing missed events.
+          -- Any of these files might still be opened for writing and being actively written-to right now.
+          let isAtomic = False
+          let addedEvent = (Added (newDir </> newPath) (posixSecondsToUTCTime timestampBeforeAddingWatch) isDir isAtomic)
           when (actPred addedEvent) $ callback addedEvent
 
     _ -> return ()

--- a/src/System/FSNotify/OSX.hs
+++ b/src/System/FSNotify/OSX.hs
@@ -72,11 +72,11 @@ fsnEvents timestamp e = do
 
   return $ if | exists && isModified -> [Modified (path e) timestamp isDirectory]
               | exists && isModifiedAttributes -> [ModifiedAttributes (path e) timestamp isDirectory]
-              | exists && isCreated -> [Added (path e) timestamp isDirectory]
+              | exists && isCreated -> [Added (path e) timestamp isDirectory False]
               | (not exists) && hasFlag e FSE.eventFlagItemRemoved -> [Removed (path e) timestamp isDirectory]
 
               -- Rename stuff
-              | exists && isRenamed -> [Added (path e) timestamp isDirectory]
+              | exists && isRenamed -> [Added (path e) timestamp isDirectory True]
               | (not exists) && isRenamed -> [Removed (path e) timestamp isDirectory]
 
               | otherwise -> []

--- a/src/System/FSNotify/Polling.hs
+++ b/src/System/FSNotify/Polling.hs
@@ -43,7 +43,7 @@ data PollManager = PollManager {
   }
 
 generateEvent :: UTCTime -> EventIsDirectory -> EventType -> FilePath -> Maybe Event
-generateEvent timestamp isDir AddedEvent filePath = Just (Added filePath timestamp isDir)
+generateEvent timestamp isDir AddedEvent filePath = Just (Added filePath timestamp isDir False)
 generateEvent timestamp isDir ModifiedEvent filePath = Just (Modified filePath timestamp isDir)
 generateEvent timestamp isDir RemovedEvent filePath = Just (Removed filePath timestamp isDir)
 

--- a/src/System/FSNotify/Types.hs
+++ b/src/System/FSNotify/Types.hs
@@ -35,7 +35,10 @@ data EventIsDirectory = IsFile | IsDirectory
 -- event occurred (timestamps represent current time when FSEvents receives
 -- it from the OS and/or platform-specific Haskell modules).
 data Event =
-    Added { eventPath :: FilePath, eventTime :: UTCTime, eventIsDirectory :: EventIsDirectory }
+    Added { eventPath :: FilePath, eventTime :: UTCTime, eventIsDirectory :: EventIsDirectory
+          -- | The file or directory under `eventPath` was added atomically through a move or rename
+          , isAtomicMove :: Bool
+          }
   | Modified { eventPath :: FilePath, eventTime :: UTCTime, eventIsDirectory :: EventIsDirectory }
   | ModifiedAttributes { eventPath :: FilePath, eventTime :: UTCTime, eventIsDirectory :: EventIsDirectory }
   | Removed { eventPath :: FilePath, eventTime :: UTCTime, eventIsDirectory :: EventIsDirectory }

--- a/src/System/FSNotify/Win32.hs
+++ b/src/System/FSNotify/Win32.hs
@@ -27,7 +27,7 @@ type NativeManager = WNo.WatchManager
 
 -- Win32-notify has (temporarily?) dropped support for Renamed events.
 fsnEvent :: EventIsDirectory -> FilePath -> UTCTime -> WNo.Event -> Event
-fsnEvent isDirectory basedir timestamp (WNo.Created name) = Added (normalise (basedir </> name)) timestamp isDirectory
+fsnEvent isDirectory basedir timestamp (WNo.Created name) = Added (normalise (basedir </> name)) timestamp isDirectory False
 fsnEvent isDirectory basedir timestamp (WNo.Modified name) = Modified (normalise (basedir </> name)) timestamp isDirectory
 fsnEvent isDirectory basedir timestamp (WNo.Deleted name) = Removed (normalise (basedir </> name)) timestamp isDirectory
 

--- a/stack-ghc96.yaml
+++ b/stack-ghc96.yaml
@@ -1,4 +1,4 @@
-resolver: lts-22.43
+resolver: lts-22.44
 
 packages:
 - '.'

--- a/stack-ghc96.yaml.lock
+++ b/stack-ghc96.yaml.lock
@@ -20,7 +20,7 @@ packages:
     hackage: hfsevents-0.1.8@sha256:0a736ab01a1c26a6e081a857254e5a6aa5c84ff5ee84a24ea91a8a2b503cea45,901
 snapshots:
 - completed:
-    sha256: 08bd13ce621b41a8f5e51456b38d5b46d7783ce114a50ab604d6bbab0d002146
-    size: 720271
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/43.yaml
-  original: lts-22.43
+    sha256: 238fa745b64f91184f9aa518fe04bdde6552533d169b0da5256670df83a0f1a9
+    size: 721141
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/44.yaml
+  original: lts-22.44

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,13 +1,1 @@
-resolver: lts-24.6
-
-packages:
-- '.'
-
-nix:
-  pure: false
-  packages:
-  - zlib
-
-# Uncomment these to test with text-2.1.2, which exports "show" by default
-# - text-2.1.2
-# - parsec-3.1.17.0
+stack-ghc96.yaml

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,10 +3,24 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/topics/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: vty-windows-0.2.0.3@sha256:0c010b1086a725046a8bb08bb1e6bfdfdb3cfe1c72d6fa77c37306ef9ec774d8,2844
+    pantry-tree:
+      sha256: 958fd0386c589130177c841df63368ff191eb296f9ed2fd050de10e266c354eb
+      size: 2160
+  original:
+    hackage: vty-windows-0.2.0.3@sha256:0c010b1086a725046a8bb08bb1e6bfdfdb3cfe1c72d6fa77c37306ef9ec774d8,2844
+- completed:
+    hackage: hfsevents-0.1.8@sha256:0a736ab01a1c26a6e081a857254e5a6aa5c84ff5ee84a24ea91a8a2b503cea45,901
+    pantry-tree:
+      sha256: 2f9ff8845959dc4632d588967d352388564b553099c7df3b56fb0ad573f916c4
+      size: 438
+  original:
+    hackage: hfsevents-0.1.8@sha256:0a736ab01a1c26a6e081a857254e5a6aa5c84ff5ee84a24ea91a8a2b503cea45,901
 snapshots:
 - completed:
-    sha256: 473840099b95facf73ec72dcafe53a2487bfadeceb03a981a19e16469503a342
-    size: 726266
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/24/6.yaml
-  original: lts-24.6
+    sha256: 238fa745b64f91184f9aa518fe04bdde6552533d169b0da5256670df83a0f1a9
+    size: 721141
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/44.yaml
+  original: lts-22.44


### PR DESCRIPTION
Hey @thomasjm, here's a raw sketch aiming to resolve #124.

Still figuring out tests here; the blurb in example/Main.hs, and the stackage bumps, those are sandbox experiments. I can  revert afterwards, if you like.

The main fix is in just the first commit; am hating the boolean-blindedness, but there's that new field under `Added`. AFAIU, that'd suffice to distinguish the two origins of Added.

By all means, welcome to request further changes